### PR TITLE
fix: failing testcases in router package

### DIFF
--- a/backend/internal/router/api_handler_test.go
+++ b/backend/internal/router/api_handler_test.go
@@ -355,7 +355,7 @@ func Test_BookDownloadAPIHandler(t *testing.T) {
 				return
 			}
 			ctx := context.WithValue(req.Context(), SERV_KEY, test.setupServ(ctrl))
-			ctx = context.WithValue(ctx, "book", test.bk)
+			ctx = context.WithValue(ctx, BOOK_KEY, test.bk)
 			req = req.WithContext(ctx)
 
 			res := httptest.NewRecorder()


### PR DESCRIPTION
fix testcases in router package
- use `BOOK_KEY` instead of `"book"` in `Test_BookDownloadAPIHandler`
- update stub `Book` Call to `BookGroup` call in `Test_GetBookMiddleware`
- 