### PR TITLE
chore/FE docker - use existing flutter image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,13 +34,14 @@ services:
         command: sh -c "./backend > /log/backend.log 2>&1"
 
     frontend:
-        image: "flutter:stable"
+        build:
+            context: ./frontend
         deploy:
             resources:
                 limits:
                     memory: '1G'
         volumes:
-            - frontend_volume:/build/web
+            - frontend_volume:/build-result/web
             - ./frontend/src:/usr/src/app
         networks:
             - router

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+# FROM ghcr.io/cirruslabs/flutter:stable
+FROM plugfox/flutter:stable-web
+
+WORKDIR /usr/src/app
+
+RUN mkdir /build-result
+RUN echo '{ "build-dir": "../../../build-result" }' > /root/.flutter_settings
+
+CMD ['flutter pub get ; flutter build web']


### PR DESCRIPTION
This PR use existing image `plugfox/flutter:stable-web` as flutter base image.