### PR TITLE
chore/chapter keyword - move ChapterEndKeywords from repo to model package

### DIFF
--- a/backend/internal/model/chapter.go
+++ b/backend/internal/model/chapter.go
@@ -6,6 +6,17 @@ import (
 	"strings"
 )
 
+var ChapterEndKeywords = []string{
+	// traditional chinese
+	"番外", "結局", "新書", "完結", "尾聲", "感言", "後記", "完本",
+	"全書完", "全文完", "全文終", "全文結", "劇終", "（完）", "終章",
+	"外傳", "結尾",
+	// simplified chinese
+	"番外", "结局", "新书", "完结", "尾声", "感言", "后记", "完本",
+	"全书完", "全文完", "全文终", "全文结", "剧终", "（完）", "终章",
+	"外传", "结尾",
+}
+
 var (
 	ErrCannotParseContent = errors.New("cannot parse content")
 )

--- a/backend/internal/repo/psql/repository.go
+++ b/backend/internal/repo/psql/repository.go
@@ -286,8 +286,8 @@ func generateUpdateStatusCondition(length int) string {
 }
 
 func (r *PsqlRepo) UpdateBooksStatus() error {
-	matchingKeywords := make([]interface{}, 0, len(repo.ChapterEndKeywords))
-	for _, keyword := range repo.ChapterEndKeywords {
+	matchingKeywords := make([]interface{}, 0, len(model.ChapterEndKeywords))
+	for _, keyword := range model.ChapterEndKeywords {
 		matchingKeywords = append(matchingKeywords, fmt.Sprintf("%%%v%%", keyword))
 	}
 

--- a/backend/internal/repo/psql/repository_test.go
+++ b/backend/internal/repo/psql/repository_test.go
@@ -686,7 +686,7 @@ func TestPsqlRepo_UpdateBooksStatus(t *testing.T) {
 			expectBook: &model.Book{
 				Site: site, ID: 3, HashCode: 0,
 				Title: "title 3", Writer: bksDB[3].Writer,
-				Type: "type 3", UpdateDate: "date 3", UpdateChapter: "end " + repo.ChapterEndKeywords[0] + " end",
+				Type: "type 3", UpdateDate: "date 3", UpdateChapter: "end " + model.ChapterEndKeywords[0] + " end",
 				Status: model.End, IsDownloaded: false,
 			},
 		},
@@ -699,7 +699,7 @@ func TestPsqlRepo_UpdateBooksStatus(t *testing.T) {
 			expectBook: &model.Book{
 				Site: site, ID: 1, HashCode: 0,
 				Title: "title 1", Writer: bksDB[0].Writer,
-				Type: "type 1", UpdateDate: "date 1", UpdateChapter: "end " + repo.ChapterEndKeywords[0] + " end",
+				Type: "type 1", UpdateDate: "date 1", UpdateChapter: "end " + model.ChapterEndKeywords[0] + " end",
 				Status: model.End, IsDownloaded: false,
 			},
 		},
@@ -725,9 +725,9 @@ func TestPsqlRepo_UpdateBooksStatus(t *testing.T) {
 
 			bksDB[2].Status = model.InProgress
 			r.UpdateBook(&bksDB[2])
-			bksDB[3].UpdateChapter = fmt.Sprintf("end %v end", repo.ChapterEndKeywords[0])
+			bksDB[3].UpdateChapter = fmt.Sprintf("end %v end", model.ChapterEndKeywords[0])
 			r.UpdateBook(&bksDB[3])
-			bksDB[0].UpdateChapter = fmt.Sprintf("end %v end", repo.ChapterEndKeywords[0])
+			bksDB[0].UpdateChapter = fmt.Sprintf("end %v end", model.ChapterEndKeywords[0])
 			bksDB[0].Status = model.InProgress
 			r.UpdateBook(&bksDB[0])
 

--- a/backend/internal/repo/repository.go
+++ b/backend/internal/repo/repository.go
@@ -6,17 +6,6 @@ import (
 	"github.com/htchan/BookSpider/internal/model"
 )
 
-var ChapterEndKeywords = []string{
-	// traditional chinese
-	"番外", "結局", "新書", "完結", "尾聲", "感言", "後記", "完本",
-	"全書完", "全文完", "全文終", "全文結", "劇終", "（完）", "終章",
-	"外傳", "結尾",
-	// simplified chinese
-	"番外", "结局", "新书", "完结", "尾声", "感言", "后记", "完本",
-	"全书完", "全文完", "全文终", "全文结", "剧终", "（完）", "终章",
-	"外传", "结尾",
-}
-
 //go:generate mockgen -destination=../mock/repo/repository.go -package=mockrepo . Repository
 type Repository interface {
 	// book related

--- a/backend/internal/repo/sqlc/repository_test.go
+++ b/backend/internal/repo/sqlc/repository_test.go
@@ -686,7 +686,7 @@ func TestSqlcRepo_UpdateBooksStatus(t *testing.T) {
 			expectBook: &model.Book{
 				Site: site, ID: 3, HashCode: 0,
 				Title: "title 3", Writer: bksDB[3].Writer,
-				Type: "type 3", UpdateDate: "date 3", UpdateChapter: "end " + repo.ChapterEndKeywords[0] + " end",
+				Type: "type 3", UpdateDate: "date 3", UpdateChapter: "end " + model.ChapterEndKeywords[0] + " end",
 				Status: model.End, IsDownloaded: false,
 			},
 		},
@@ -699,7 +699,7 @@ func TestSqlcRepo_UpdateBooksStatus(t *testing.T) {
 			expectBook: &model.Book{
 				Site: site, ID: 1, HashCode: 0,
 				Title: "title 1", Writer: bksDB[0].Writer,
-				Type: "type 1", UpdateDate: "date 1", UpdateChapter: "end " + repo.ChapterEndKeywords[0] + " end",
+				Type: "type 1", UpdateDate: "date 1", UpdateChapter: "end " + model.ChapterEndKeywords[0] + " end",
 				Status: model.End, IsDownloaded: false,
 			},
 		},
@@ -725,9 +725,9 @@ func TestSqlcRepo_UpdateBooksStatus(t *testing.T) {
 
 			bksDB[2].Status = model.InProgress
 			r.UpdateBook(&bksDB[2])
-			bksDB[3].UpdateChapter = fmt.Sprintf("end %v end", repo.ChapterEndKeywords[0])
+			bksDB[3].UpdateChapter = fmt.Sprintf("end %v end", model.ChapterEndKeywords[0])
 			r.UpdateBook(&bksDB[3])
-			bksDB[0].UpdateChapter = fmt.Sprintf("end %v end", repo.ChapterEndKeywords[0])
+			bksDB[0].UpdateChapter = fmt.Sprintf("end %v end", model.ChapterEndKeywords[0])
 			bksDB[0].Status = model.InProgress
 			r.UpdateBook(&bksDB[0])
 

--- a/backend/internal/service/v1/book_operations.go
+++ b/backend/internal/service/v1/book_operations.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/htchan/BookSpider/internal/model"
-	"github.com/htchan/BookSpider/internal/repo"
 	serv "github.com/htchan/BookSpider/internal/service"
 	vendor "github.com/htchan/BookSpider/internal/vendorservice"
 	"github.com/rs/zerolog"
@@ -354,7 +353,7 @@ func isEnd(bk *model.Book) bool {
 	}
 
 	chapter := strings.ReplaceAll(bk.UpdateChapter, " ", "")
-	for _, keyword := range repo.ChapterEndKeywords {
+	for _, keyword := range model.ChapterEndKeywords {
 		if strings.Contains(chapter, keyword) {
 			return true
 		}

--- a/backend/internal/service_new/validate.go
+++ b/backend/internal/service_new/validate.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/htchan/BookSpider/internal/model"
-	"github.com/htchan/BookSpider/internal/repo"
 )
 
 func isEnd(bk *model.Book) bool {
@@ -20,7 +19,7 @@ func isEnd(bk *model.Book) bool {
 	}
 
 	chapter := strings.ReplaceAll(bk.UpdateChapter, " ", "")
-	for _, keyword := range repo.ChapterEndKeywords {
+	for _, keyword := range model.ChapterEndKeywords {
 		if strings.Contains(chapter, keyword) {
 			return true
 		}


### PR DESCRIPTION
This PR moves `ChapterEndKeywords` from `repo` package to `model` package.