### PR TITLE
chore/uukanshu - set date as start of year

### DIFF
--- a/backend/internal/vendorservice/uukanshu/parser.go
+++ b/backend/internal/vendorservice/uukanshu/parser.go
@@ -64,6 +64,11 @@ func (p *VendorService) ParseBook(body string) (*vendor.BookInfo, error) {
 		date = date.AddDate(0, 0, -day)
 	}
 
+	// update the date to beginning of that year if the book is older than a year.
+	if time.Since(date) > 365*36*time.Hour {
+		date = time.Date(date.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+
 	// parse chapter
 	chapter := vendor.GetGoqueryContentWithoutChildren(doc.Find(bookChapterGoquerySelector))
 	if chapter == "" {


### PR DESCRIPTION
In `uukanshu`, if the book last update date is 1.5 yr ago, it will set the date to the beginning of the year.