### PR TITLE
fix(security): upgrade Go from 1.26.1 to 1.26.2

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
 
 jobs:
   Build-Push-Backend-Image:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * 6'
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
 
 jobs:
   security-scan:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/test.yml'
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
 
 jobs:
   Execute-Backend-Testcase:

--- a/build/Dockerfile.console
+++ b/build/Dockerfile.console
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /go/src/github.com/htchan/BookSpider
 

--- a/build/Dockerfile.test
+++ b/build/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /go/src/github.com/htchan/BookSpider
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ variable "BAKE_CI" { default = "false" }
 
 variable "BRANCH" { default = "" }
 variable "IMAGE_TAG" { default = "${equal(BRANCH,"master") ? "latest" : "beta"}" }
-variable "GO_VERSION" { default = "1.26.1" }
+variable "GO_VERSION" { default = "1.26.2" }
 
 group "default" {
   targets = ["backend-api","backend-worker"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/htchan/BookSpider
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0


### PR DESCRIPTION
This PR fixes 5 Go standard library vulnerabilities by upgrading from Go 1.26.1 to 1.26.2:

- GO-2026-4947: Unexpected work during chain building in crypto/x509
- GO-2026-4946: Inefficient policy validation in crypto/x509
- GO-2026-4870: Unauthenticated TLS 1.3 KeyUpdate in crypto/tls
- GO-2026-4866: Case-sensitive excludedSubtrees in crypto/x509
- GO-2026-4865: JsBraceDepth Context Tracking Bugs in html/template