### PR TITLE
fix(security): upgrade Go version from 1.26.3 to 1.26.4

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   Build-Push-Backend-Image:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * 6'
 
 env:
-   GO_VERSION: 1.26.3
+   GO_VERSION: 1.26.4
 
 jobs:
   security-scan:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/test.yml'
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   Execute-Backend-Testcase:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,7 +8,7 @@ variable "BAKE_CI" { default = "false" }
 
 variable "BRANCH" { default = "" }
 variable "IMAGE_TAG" { default = "${equal(BRANCH,"master") ? "latest" : "beta"}" }
-variable "GO_VERSION" { default = "1.26.3" }
+variable "GO_VERSION" { default = "1.26.4" }
 
 group "default" {
   targets = ["backend-api","backend-worker"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/htchan/BookSpider
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0


### PR DESCRIPTION
Upgrade Go version to 1.26.4 to fix security vulnerabilities GO-2026-5039 and GO-2026-5037